### PR TITLE
Add Encoder-Decoder JEPA-Style Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ For a detailed description, see **[`docs/03_encoder_decoder_model.md`](docs/03_e
 
 For a detailed description, see **[`docs/04_jepa_model.md`](docs/04_jepa_model.md)**.
 
+### 3. Encoder-Decoder JEPA-Style (Fair JEPA Baseline)
+*   **Encoder:** Configurable (ViT, CNN, or MLP), same as other models.
+*   **Predictor:** A JEPA-style MLP takes the concatenated encoder output and action embedding, producing a latent vector.
+*   **Decoder:** A Transformer-based decoder reconstructs the next state image from the predictor's output.
+*   **Purpose:** This model is designed for apples-to-apples comparison with JEPA, matching parameter count and architectural complexity. It allows rigorous evaluation of whether JEPA's performance gains are due to its modeling principle or simply model capacity.
+*   **Output:** Predicts the next state in pixel space, just like the standard Encoder-Decoder, but with a JEPA-style predictor in the pipeline.
+
 ## Contributing
 
 Contributions to this project are welcome. Please refer to the documentation and existing code structure for guidance. (Further details on contributing can be added here or in a separate `CONTRIBUTING.md` file).

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@ dataset_filename: "car_racing_v3_v2.pkl"
 # Model Loading Configuration
 model_dir: "trained_models/"
 load_model_path: "" # empty string means don't load, otherwise it's a path relative to model_dir
-model_type_to_load: "" # options: "std_enc_dec", "jepa", or potentially others if the system supports more
+model_type_to_load: "enc_dec_jepa_style" # options: "std_enc_dec", "jepa", "enc_dec_jepa_style"
 
 # Training Configuration
 frame_skipping: 0 # Number of frames to skip (0 means no skipping). Note: If using action_repetition_k in PPO data collection, this should ideally be 0 to avoid compounded effects.
@@ -191,3 +191,9 @@ wandb:
   entity: null
   run_name_prefix: "exp"
   enabled: true
+
+# Encoder-Decoder JEPA-Style Model (for fair JEPA comparison)
+enc_dec_jepa_style_predictor_hidden_dim: 256 # Hidden dim for the predictor MLP in the JEPA-style encoder-decoder
+enc_dec_jepa_style_predictor_output_dim: 128 # Output dim of the predictor (should match decoder input dim)
+enc_dec_jepa_style_predictor_dropout_rate: 0.3 # Dropout rate for predictor MLP
+# The decoder parameters (decoder_dim, decoder_depth, decoder_heads, decoder_mlp_dim, decoder_dropout, decoder_patch_size) are shared with the standard encoder-decoder above.

--- a/docs/03_encoder_decoder_model.md
+++ b/docs/03_encoder_decoder_model.md
@@ -104,3 +104,21 @@ The behavior, architecture, and training of the Standard Encoder-Decoder model a
 -   **`training_options.skip_std_enc_dec_training_if_loaded`**: (boolean) If `true`, and a pre-trained Standard Encoder-Decoder model is successfully loaded (via `model_type_to_load` and `load_model_path`), the training phase for this model will be skipped.
 
 For a comprehensive list of all configuration options and their detailed explanations, please refer directly to the `config.yaml` file (which is heavily commented) and the **[`docs/06_usage_guide.md`](../06_usage_guide.md)**.
+
+## Encoder-Decoder JEPA-Style Variant (Fair JEPA Baseline)
+
+To enable rigorous, apples-to-apples comparison with JEPA, this repository includes an **Encoder-Decoder JEPA-style** model variant. This model:
+
+- Uses the same encoder options (ViT, CNN, MLP) as the standard Encoder-Decoder and JEPA.
+- After encoding the current state, concatenates the action embedding (as in both current models).
+- Passes the concatenated vector through a JEPA-style predictor MLP (identical to the one used in JEPA).
+- Feeds the predictor's output into a Transformer-based decoder (as in the standard Encoder-Decoder and JEPAStateDecoder) to reconstruct the next state image in pixel space.
+- All architectural parameters (encoder, predictor, decoder) are fully configurable via `config.yaml`.
+
+**Purpose:**
+This model is designed to match the parameter count and architectural complexity of JEPA as closely as possible, isolating the effect of the core modeling principle (predicting in pixel space vs. embedding space). By comparing this model to both the standard Encoder-Decoder and JEPA, researchers can determine whether JEPA's performance gains are due to its architectural philosophy or simply increased model capacity.
+
+**Usage:**
+- Select this model by setting `model_type_to_load: "enc_dec_jepa_style"` in `config.yaml`.
+- Configure all relevant parameters (encoder, predictor, decoder) as for the other models.
+- The model can be trained and evaluated using the same training and reward prediction pipelines as the other world models.

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -4,7 +4,8 @@ from .encoder_decoder import StandardEncoderDecoder
 from .jepa import JEPA
 from .cnn import CNNEncoder
 from .mlp import MLPEncoder
-from .jepa_state_decoder import JEPAStateDecoder # Added line
+from .jepa_state_decoder import JEPAStateDecoder
+from .encoder_decoder_jepa_style import EncoderDecoderJEPAStyle
 
 __all__ = [
     "ViT",
@@ -12,5 +13,6 @@ __all__ = [
     "JEPA",
     "CNNEncoder",
     "MLPEncoder",
-    "JEPAStateDecoder" # Added line
+    "JEPAStateDecoder",
+    "EncoderDecoderJEPAStyle"
 ]

--- a/src/models/encoder_decoder_jepa_style.py
+++ b/src/models/encoder_decoder_jepa_style.py
@@ -1,0 +1,171 @@
+import torch
+import torch.nn as nn
+from einops.layers.torch import Rearrange
+from .vit import ViT
+from .cnn import CNNEncoder
+from .mlp import MLPEncoder
+from src.utils.weight_init import initialize_weights
+
+class EncoderDecoderJEPAStyle(nn.Module):
+    """
+    Encoder-Decoder model with JEPA-style predictor MLP and Transformer decoder.
+    This model is designed for apples-to-apples comparison with JEPA:
+    - Uses the same encoder options (ViT, CNN, MLP).
+    - After encoding the current state, concatenates the action embedding.
+    - Passes the concatenated vector through a JEPA-style predictor MLP.
+    - The predictor's output is fed into a Transformer-based decoder to reconstruct the next state image in pixel space.
+    - All architectural parameters are fully configurable for fair comparison.
+    """
+    def __init__(self,
+                 image_size,  # int or tuple (h, w)
+                 patch_size,  # For ViT and decoder's output patch structure
+                 input_channels,
+                 action_dim,
+                 action_emb_dim,
+                 latent_dim,  # Output dim of encoder
+                 predictor_hidden_dim,
+                 predictor_output_dim,  # Should match decoder input dim
+                 predictor_dropout_rate=0.0,
+                 decoder_dim=128,
+                 decoder_depth=3,
+                 decoder_heads=4,
+                 decoder_mlp_dim=256,
+                 output_channels=3,
+                 output_image_size=None,  # int or tuple (h,w)
+                 decoder_dropout=0.0,
+                 encoder_type='vit',
+                 encoder_params: dict = None,
+                 decoder_patch_size: int = None):
+        super().__init__()
+
+        self._image_size_tuple = image_size if isinstance(image_size, tuple) else (image_size, image_size)
+        self._output_image_size_tuple = output_image_size if output_image_size is not None else self._image_size_tuple
+        self.input_channels = input_channels
+        self.output_channels = output_channels
+
+        # Determine decoder_patch_size
+        self.decoder_patch_size = decoder_patch_size if decoder_patch_size is not None else patch_size
+        if self._output_image_size_tuple[0] % self.decoder_patch_size != 0 or \
+           self._output_image_size_tuple[1] % self.decoder_patch_size != 0:
+            raise ValueError(
+                f"Output image dimensions ({self._output_image_size_tuple}) must be divisible by the decoder_patch_size ({self.decoder_patch_size}).")
+        self.output_num_patches_h = self._output_image_size_tuple[0] // self.decoder_patch_size
+        self.output_num_patches_w = self._output_image_size_tuple[1] // self.decoder_patch_size
+        self.num_output_patches = self.output_num_patches_h * self.output_num_patches_w
+
+        # Encoder instantiation (reuse logic from StandardEncoderDecoder)
+        if encoder_params is None:
+            encoder_params = {}
+        if encoder_type == 'vit':
+            vit_params = {
+                'image_size': self._image_size_tuple,
+                'patch_size': patch_size,
+                'channels': input_channels,
+                'num_classes': 0,
+                'dim': latent_dim,
+                'depth': encoder_params.get('depth', 6),
+                'heads': encoder_params.get('heads', 8),
+                'mlp_dim': encoder_params.get('mlp_dim', 1024),
+                'pool': encoder_params.get('pool', 'cls'),
+                'dropout': encoder_params.get('dropout', 0.),
+                'emb_dropout': encoder_params.get('emb_dropout', 0.)
+            }
+            self.encoder = ViT(**vit_params)
+        elif encoder_type == 'cnn':
+            cnn_params = {
+                'input_channels': input_channels,
+                'image_size': self._image_size_tuple,
+                'latent_dim': latent_dim,
+                'num_conv_layers': encoder_params.get('num_conv_layers', 3),
+                'base_filters': encoder_params.get('base_filters', 32),
+                'kernel_size': encoder_params.get('kernel_size', 3),
+                'stride': encoder_params.get('stride', 2),
+                'padding': encoder_params.get('padding', 1),
+                'activation_fn_str': encoder_params.get('activation_fn_str', 'relu'),
+                'fc_hidden_dim': encoder_params.get('fc_hidden_dim', None),
+                'dropout_rate': encoder_params.get('dropout_rate', 0.0)
+            }
+            self.encoder = CNNEncoder(**cnn_params)
+        elif encoder_type == 'mlp':
+            mlp_params = {
+                'input_channels': input_channels,
+                'image_size': self._image_size_tuple,
+                'latent_dim': latent_dim,
+                'num_hidden_layers': encoder_params.get('num_hidden_layers', 2),
+                'hidden_dim': encoder_params.get('hidden_dim', 512),
+                'activation_fn_str': encoder_params.get('activation_fn_str', 'relu'),
+                'dropout_rate': encoder_params.get('dropout_rate', 0.0)
+            }
+            self.encoder = MLPEncoder(**mlp_params)
+        else:
+            raise ValueError(f"Unsupported encoder_type: {encoder_type}")
+
+        # Action embedding
+        self.action_embedding = nn.Linear(action_dim, action_emb_dim)
+
+        # JEPA-style predictor MLP
+        predictor_layers = [
+            nn.Linear(latent_dim + action_emb_dim, predictor_hidden_dim),
+            nn.GELU()
+        ]
+        if predictor_dropout_rate > 0:
+            predictor_layers.append(nn.Dropout(predictor_dropout_rate))
+        predictor_layers.extend([
+            nn.Linear(predictor_hidden_dim, predictor_hidden_dim),
+            nn.GELU()
+        ])
+        if predictor_dropout_rate > 0:
+            predictor_layers.append(nn.Dropout(predictor_dropout_rate))
+        predictor_layers.append(nn.Linear(predictor_hidden_dim, predictor_output_dim))
+        self.predictor = nn.Sequential(*predictor_layers)
+
+        # Transformer Decoder (same as StandardEncoderDecoder/JEPAStateDecoder)
+        decoder_layer = nn.TransformerDecoderLayer(
+            d_model=decoder_dim,
+            nhead=decoder_heads,
+            dim_feedforward=decoder_mlp_dim,
+            dropout=decoder_dropout,
+            batch_first=True
+        )
+        self.transformer_decoder = nn.TransformerDecoder(
+            decoder_layer=decoder_layer,
+            num_layers=decoder_depth
+        )
+        self.decoder_query_tokens = nn.Parameter(torch.randn(1, self.num_output_patches, decoder_dim) * 0.02)
+        output_patch_dim = self.output_channels * self.decoder_patch_size * self.decoder_patch_size
+        self.to_pixels = nn.Linear(decoder_dim, output_patch_dim)
+        self.patch_to_image = Rearrange(
+            'b (h w) (p1 p2 c) -> b c (h p1) (w p2)',
+            p1=self.decoder_patch_size, p2=self.decoder_patch_size,
+            h=self.output_num_patches_h, w=self.output_num_patches_w,
+            c=self.output_channels
+        )
+        self.apply(initialize_weights)
+
+    def forward(self, current_state_img, action):
+        """
+        Args:
+            current_state_img: (batch, channels, height, width)
+            action: (batch, action_dim)
+        Returns:
+            predicted_next_state_img: (batch, output_channels, output_image_h, output_image_w)
+        """
+        # 1. Encode current state
+        latent_s_t = self.encoder(current_state_img)  # (b, latent_dim)
+        # 2. Embed action
+        embedded_action = self.action_embedding(action)  # (b, action_emb_dim)
+        # 3. Concatenate and pass through predictor
+        predictor_input = torch.cat((latent_s_t, embedded_action), dim=-1)  # (b, latent_dim + action_emb_dim)
+        predictor_output = self.predictor(predictor_input)  # (b, predictor_output_dim)
+        # 4. Project predictor output to decoder_dim and unsqueeze for memory
+        decoder_memory = predictor_output.unsqueeze(1)  # (b, 1, decoder_dim) if dims match
+        # 5. Prepare query tokens
+        batch_size = current_state_img.shape[0]
+        query_tokens = self.decoder_query_tokens.repeat(batch_size, 1, 1)  # (b, num_output_patches, decoder_dim)
+        # 6. Pass through Transformer Decoder
+        decoded_representation = self.transformer_decoder(tgt=query_tokens, memory=decoder_memory)
+        # 7. Map to pixel values
+        pixel_patches = self.to_pixels(decoded_representation)
+        # 8. Reshape patches to image
+        predicted_next_state_img = self.patch_to_image(pixel_patches)
+        return predicted_next_state_img 

--- a/tests/test_enc_dec_jepa_style.py
+++ b/tests/test_enc_dec_jepa_style.py
@@ -1,0 +1,125 @@
+import unittest
+import torch
+from src.models.encoder_decoder_jepa_style import EncoderDecoderJEPAStyle
+from src.models.encoder_decoder import StandardEncoderDecoder
+from src.models.jepa import JEPA
+from src.models.mlp import RewardPredictorMLP
+
+class TestEncoderDecoderJEPAStyle(unittest.TestCase):
+    def setUp(self):
+        self.batch_size = 2
+        self.img_size = 16
+        self.input_channels = 3
+        self.action_dim = 4
+        self.action_emb_dim = 8
+        self.latent_dim = 16
+        self.predictor_hidden_dim = 12
+        self.predictor_output_dim = 10
+        self.decoder_dim = 10
+        self.decoder_depth = 2
+        self.decoder_heads = 2
+        self.decoder_mlp_dim = 20
+        self.decoder_patch_size = 4
+        self.output_channels = 3
+        self.device = torch.device('cpu')
+        self.dummy_img = torch.randn(self.batch_size, self.input_channels, self.img_size, self.img_size)
+        self.dummy_action = torch.randn(self.batch_size, self.action_dim)
+
+    def test_forward_shape(self):
+        model = EncoderDecoderJEPAStyle(
+            image_size=self.img_size,
+            patch_size=self.decoder_patch_size,
+            input_channels=self.input_channels,
+            action_dim=self.action_dim,
+            action_emb_dim=self.action_emb_dim,
+            latent_dim=self.latent_dim,
+            predictor_hidden_dim=self.predictor_hidden_dim,
+            predictor_output_dim=self.decoder_dim,
+            predictor_dropout_rate=0.0,
+            decoder_dim=self.decoder_dim,
+            decoder_depth=self.decoder_depth,
+            decoder_heads=self.decoder_heads,
+            decoder_mlp_dim=self.decoder_mlp_dim,
+            output_channels=self.output_channels,
+            output_image_size=(self.img_size, self.img_size),
+            decoder_dropout=0.0,
+            encoder_type='mlp',
+            encoder_params={'num_hidden_layers': 1, 'hidden_dim': 20, 'activation_fn_str': 'relu', 'dropout_rate': 0.0},
+            decoder_patch_size=self.decoder_patch_size
+        ).to(self.device)
+        out = model(self.dummy_img, self.dummy_action)
+        self.assertEqual(out.shape, (self.batch_size, self.output_channels, self.img_size, self.img_size))
+
+    def test_loss_decreases(self):
+        model = EncoderDecoderJEPAStyle(
+            image_size=self.img_size,
+            patch_size=self.decoder_patch_size,
+            input_channels=self.input_channels,
+            action_dim=self.action_dim,
+            action_emb_dim=self.action_emb_dim,
+            latent_dim=self.latent_dim,
+            predictor_hidden_dim=self.predictor_hidden_dim,
+            predictor_output_dim=self.decoder_dim,
+            predictor_dropout_rate=0.0,
+            decoder_dim=self.decoder_dim,
+            decoder_depth=self.decoder_depth,
+            decoder_heads=self.decoder_heads,
+            decoder_mlp_dim=self.decoder_mlp_dim,
+            output_channels=self.output_channels,
+            output_image_size=(self.img_size, self.img_size),
+            decoder_dropout=0.0,
+            encoder_type='mlp',
+            encoder_params={'num_hidden_layers': 1, 'hidden_dim': 20, 'activation_fn_str': 'relu', 'dropout_rate': 0.0},
+            decoder_patch_size=self.decoder_patch_size
+        ).to(self.device)
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-2)
+        criterion = torch.nn.MSELoss()
+        target = torch.randn(self.batch_size, self.output_channels, self.img_size, self.img_size)
+        losses = []
+        for _ in range(10):
+            optimizer.zero_grad()
+            out = model(self.dummy_img, self.dummy_action)
+            loss = criterion(out, target)
+            loss.backward()
+            optimizer.step()
+            losses.append(loss.item())
+        self.assertLess(losses[-1], losses[0])
+
+    def test_reward_predictor_mlp_compatibility(self):
+        # Test that reward predictor MLP can be used with the encoder output
+        model = EncoderDecoderJEPAStyle(
+            image_size=self.img_size,
+            patch_size=self.decoder_patch_size,
+            input_channels=self.input_channels,
+            action_dim=self.action_dim,
+            action_emb_dim=self.action_emb_dim,
+            latent_dim=self.latent_dim,
+            predictor_hidden_dim=self.predictor_hidden_dim,
+            predictor_output_dim=self.decoder_dim,
+            predictor_dropout_rate=0.0,
+            decoder_dim=self.decoder_dim,
+            decoder_depth=self.decoder_depth,
+            decoder_heads=self.decoder_heads,
+            decoder_mlp_dim=self.decoder_mlp_dim,
+            output_channels=self.output_channels,
+            output_image_size=(self.img_size, self.img_size),
+            decoder_dropout=0.0,
+            encoder_type='mlp',
+            encoder_params={'num_hidden_layers': 1, 'hidden_dim': 20, 'activation_fn_str': 'relu', 'dropout_rate': 0.0},
+            decoder_patch_size=self.decoder_patch_size
+        ).to(self.device)
+        # Get encoder output
+        with torch.no_grad():
+            latent = model.encoder(self.dummy_img)
+        reward_mlp = RewardPredictorMLP(
+            input_dim=latent.shape[1],
+            hidden_dims=[8, 4],
+            activation_fn_str='relu',
+            use_batch_norm=False,
+            dropout_rate=0.0
+        ).to(self.device)
+        reward = reward_mlp(latent)
+        self.assertEqual(reward.shape, (self.batch_size, 1))
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
Introduce a new Encoder-Decoder JEPA-style model for fair comparison with JEPA. This model includes configurable encoder options and a JEPA-style predictor, allowing for rigorous evaluation of performance gains. Update configuration and documentation to support this addition. Include unit tests to validate functionality and compatibility with existing components.